### PR TITLE
fix(deps): bump js-yaml to 3.15.1 to patch CVE-2026-59869

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,9 +2466,9 @@ js-types@^1.0.0:
   integrity sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=
 
 js-yaml@^3.5.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Summary

Fixes the high-severity Dependabot alert for [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869: **js-yaml — YAML merge-key chains can force quadratic CPU consumption.**

- `yarn.lock`: js-yaml `3.13.1` → `3.15.1`

Lockfile-only change — js-yaml is a transitive dependency and the depending range (`^3.5.1`) already admits the patched version. No `package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)